### PR TITLE
Fix linter errors and var renaming for consistency

### DIFF
--- a/cmd/streamdeck-cli/main.go
+++ b/cmd/streamdeck-cli/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	// RootCmd is the core command used for cli-arg parsing
+	// RootCmd is the core command used for cli-arg parsing.
 	RootCmd = &cobra.Command{
 		Use:           "streamdeck-cli",
 		Short:         "streamdeck-cli lets you control your Elgato Stream Deck",


### PR DESCRIPTION
This PR does only contain some fixes (linter).
Futhermore I renamed some vars and methods for consistency and added the Keys field.
This should ease the usage with `deckmaster` to directly access the number of keys.
