### PR TITLE
Fix streamdeck mini

### DIFF
--- a/streamdeck.go
+++ b/streamdeck.go
@@ -128,7 +128,7 @@ func Devices() ([]Device, error) {
 				featureReportSize:    17,
 				firmwareOffset:       5,
 				keyStateOffset:       1,
-				translateKeyIndex:    translateRightToLeft,
+				translateKeyIndex:    identity,
 				imagePageSize:        1024,
 				imagePageHeaderSize:  16,
 				imagePageHeader:      miniImagePageHeader,

--- a/streamdeck.go
+++ b/streamdeck.go
@@ -129,7 +129,7 @@ func Devices() ([]Device, error) {
 				translateKeyIndex:    translateRightToLeft,
 				imagePageSize:        1024,
 				imagePageHeaderSize:  16,
-				imagePageHeader:      rev1ImagePageHeader,
+				imagePageHeader:      miniImagePageHeader,
 				toImageFormat:        toBMP,
 				getFirmwareCommand:   c_REV1_FIRMWARE,
 				resetCommand:         c_REV1_RESET,
@@ -507,7 +507,7 @@ func toJPEG(img image.Image) ([]byte, error) {
 	return buffer.Bytes(), err
 }
 
-// rev1ImagePageHeader returns the image page header sequence used by the Stream Deck v1 and Stream Deck Mini.
+// rev1ImagePageHeader returns the image page header sequence used by the Stream Deck v1.
 func rev1ImagePageHeader(pageIndex int, keyIndex uint8, payloadLength int, lastPage bool) []byte {
 	var lastPageByte byte
 	if lastPage {
@@ -516,6 +516,21 @@ func rev1ImagePageHeader(pageIndex int, keyIndex uint8, payloadLength int, lastP
 	return []byte{
 		0x02, 0x01,
 		byte(pageIndex + 1), 0x00,
+		lastPageByte,
+		keyIndex + 1,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+}
+
+// miniImagePageHeader returns the image page header sequence used by the Stream Deck Mini.
+func miniImagePageHeader(pageIndex int, keyIndex uint8, payloadLength int, lastPage bool) []byte {
+	var lastPageByte byte
+	if lastPage {
+		lastPageByte = 1
+	}
+	return []byte{
+		0x02, 0x01,
+		byte(pageIndex), 0x00,
 		lastPageByte,
 		keyIndex + 1,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,


### PR DESCRIPTION
As described in [this issue](https://github.com/muesli/deckmaster/issues/85) no images are shown on my Stream Deck Mini buttons when running deckmaster or using the CLI.

After some digging around I compared the headers sent when setting images on the device with the ones from the [Python module](https://github.com/abcminiuser/python-elgato-streamdeck). Doing so I saw that there're small differences from the original Rev 1 Stream Decks on the Mini.

Changing the header to use a zero based `pageIndex` fixed the issue with the images not being shown.
Also the image orientation is also different from other models. Therefore the code is changed to rotate images for Minis.
Key indices is also not reversed for the mini.

With this set of changes it works perfectly fine on my device.