### PR TITLE
Fix setting images via CLI

### DIFF
--- a/cmd/streamdeck-cli/image.go
+++ b/cmd/streamdeck-cli/image.go
@@ -39,7 +39,7 @@ var (
 				return err
 			}
 
-			return d.SetImage(uint8(key), resize.Resize(72, 72, img, resize.Lanczos3))
+			return d.SetImage(uint8(key), resize.Resize(d.Pixels, d.Pixels, img, resize.Lanczos3))
 		},
 	}
 )


### PR DESCRIPTION
The image command of the cli scales images to 72x72 pixel. While this is valid for the original streamdeck (both rev 1 and rev 2), it isn't for the other models. Therefore the device configuration is used now to determine the image size.