### PR TITLE
Streamdeck mini mk2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0063", MODE:="666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006c", MODE:="666", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006d", MODE:="666", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0080", MODE:="666", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0090", MODE:="666", GROUP="plugdev"
 ```
 
 Make sure your user is part of the `plugdev` group and reload the rules with

--- a/streamdeck.go
+++ b/streamdeck.go
@@ -23,12 +23,13 @@ const (
 //nolint:revive
 // Stream Deck Vendor & Product IDs.
 const (
-	VID_ELGATO          = 0x0fd9
-	PID_STREAMDECK      = 0x0060
-	PID_STREAMDECK_V2   = 0x006d
-	PID_STREAMDECK_MK2  = 0x0080
-	PID_STREAMDECK_MINI = 0x0063
-	PID_STREAMDECK_XL   = 0x006c
+	VID_ELGATO              = 0x0fd9
+	PID_STREAMDECK          = 0x0060
+	PID_STREAMDECK_V2       = 0x006d
+	PID_STREAMDECK_MK2      = 0x0080
+	PID_STREAMDECK_MINI     = 0x0063
+	PID_STREAMDECK_MINI_MK2 = 0x0090
+	PID_STREAMDECK_XL       = 0x006c
 )
 
 //nolint:revive
@@ -122,7 +123,7 @@ func Devices() ([]Device, error) {
 				resetCommand:         c_REV1_RESET,
 				setBrightnessCommand: c_REV1_BRIGHTNESS,
 			}
-		case d.VendorID == VID_ELGATO && d.ProductID == PID_STREAMDECK_MINI:
+		case d.VendorID == VID_ELGATO && (d.ProductID == PID_STREAMDECK_MINI || d.ProductID == PID_STREAMDECK_MINI_MK2):
 			dev = Device{
 				ID:                   d.Path,
 				Serial:               d.Serial,


### PR DESCRIPTION
I just bought a new Stream Deck mini, but it didn't work immediately. Its got a new product ID according to `lsusb`:

    Bus 001 Device 014: ID 0fd9:0090 Elgato Systems GmbH Stream Deck Mini

It returns the following firmware version: 2.01.002

I've added it and it now functions correctly. The images load properly and the buttons work.

I'm not sure if I should call it `PID_STREAMDECK_MINI_MK2`.